### PR TITLE
Add TypeScript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2025-07-08
+
+### Added
+- **TypeScript Definitions** - Bundled `lib/json-file-crud.d.ts` for IDE support
+
 
 ## [1.1.0] - 2025-07-07
 
@@ -92,7 +99,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Future Improvements
-- TypeScript support with .d.ts files
 - Promise-based API (async/await)
 - Batch operations (createMany, updateMany, deleteMany)
 - File locking for multi-process safety

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ node examples/basic-usage.js
 
 ## TypeScript Support
 
-While this library is written in JavaScript, you can use it in TypeScript projects. Type definitions may be added in future versions.
+Type definitions are provided via `lib/json-file-crud.d.ts` so the library can be used comfortably in TypeScript projects with autocompletion and compile-time checks.
 
 ## File Format
 

--- a/lib/json-file-crud.d.ts
+++ b/lib/json-file-crud.d.ts
@@ -1,0 +1,29 @@
+export interface CrudOptions {
+  idField?: string;
+  autoId?: boolean;
+  uniqueFields?: string[];
+}
+
+export type Callback<T> = (err: Error | null, result: T) => void;
+
+export default class JsonFileCRUD<T = any> {
+  constructor(filePath: string, options?: CrudOptions);
+
+  readonly filePath: string;
+  readonly idField: string;
+  readonly autoId: boolean;
+  readonly uniqueFields: string[];
+
+  create(item: T, callback: Callback<T>): void;
+  readAll(callback: Callback<T[]>): void;
+  findById(id: any, callback: Callback<T>): void;
+  findBy(filterFn: (item: T) => boolean, callback: Callback<T[]>): void;
+  count(callback: Callback<number>): void;
+  update(id: any, data: Partial<T>, callback: Callback<T>): void;
+  delete(id: any, callback: Callback<T>): void;
+  deleteAll(callback: (err: Error | null) => void): void;
+  writeAll(items: T[], callback: (err: Error | null) => void): void;
+  processWriteQueue(): void;
+}
+
+export function createCrud<T = any>(filePath: string, options?: CrudOptions): JsonFileCRUD<T>;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@r-el/json-file-crud",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "title": "JsonFileCRUD",
   "description": "A simple, robust, and thread-safe CRUD library for managing JSON objects in files with unique fields, auto-ID, and advanced features",
   "main": "./lib/json-file-crud.js",
+  "types": "./lib/json-file-crud.d.ts",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"


### PR DESCRIPTION
## Summary
- provide `lib/json-file-crud.d.ts` with type information
- expose definitions via `types` field in package.json
- document TypeScript support in README
- bump version and changelog for v1.2.0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c0941cc3083239ec30d75c6afabb9